### PR TITLE
[#92] Add detailed boxes ( child of plan.js ) for schedule

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -275,13 +275,19 @@
 
 .plan-container .schedule-container{
   margin-top: 50px;
-}
-
-.plan-container .schedule-container .schedule{
-  max-height: 350px;
+  
 }
 
 .plan-container .schedule-container .VerticalViewLayout-container-124{
-  height: 300px;
+  height: 400px;
   overflow: scroll;
 }
+
+.card-container{
+  height: 120px;
+  width: 280px;
+}
+
+
+
+

--- a/client/src/components/box-child.js
+++ b/client/src/components/box-child.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import Grid from "@material-ui/core/Grid";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Divider from '@material-ui/core/Divider';
+import Typography from '@material-ui/core/Typography';
+
+const childBox = (props) => {
+  
+ 
+    return (
+      <div className="box-container"> 
+        <Grid container>
+          <Grid item xs={12}>
+            <Grid container >
+              <Card className="card-container">
+                <CardContent> 
+                
+                   <Typography color="inherit">
+                      {props.titleClass}
+                    </Typography>
+                    <Typography color="inherit">
+                      {props.subject}
+                    </Typography>
+                    
+                    <Typography color="inherit">
+                    {props.semester}
+                    </Typography>
+
+                    <Typography color="inherit">
+                    {props.lecture}
+                    </Typography>
+                   
+                    <Typography color="inherit">
+                    {props.tutorial}
+                    </Typography>
+                   
+                  
+                </CardContent>
+              
+              </Card>
+            </Grid>
+          </Grid>
+        </Grid>
+  
+      </div>
+    )
+}
+
+export default childBox;

--- a/client/src/components/plan.js
+++ b/client/src/components/plan.js
@@ -18,6 +18,10 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ChildBox from './box-child';
+
+
+
 
 
 // Fake data
@@ -90,12 +94,18 @@ function createRow(id, courseNum, courseTitle, credits){
   return {id, courseNum, courseTitle, credits}
 }
 
+
+
 class Plan extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
       data: classes,
+      class: 'COMP-472',
+      subject: 'Artificial Intelligence',
+      lecture: 'LEC LL 1234, Hall building 937',
+      tutorial: 'TUT A, Hall building 435 '
     };
   }
 
@@ -108,30 +118,59 @@ class Plan extends Component {
           <h3> CourseBin</h3>
         </div>
         <Row>
-          <Col xs={2} />
-          <Col xs={8} className='schedule-container'>
+        
+          <Col xs={1} />
+          <Col xs={10} className='schedule-container'>
             <ExpansionPanel>
               <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography>Fall 2019</Typography>
               </ExpansionPanelSummary>
+              
               <ExpansionPanelDetails>
-                <div className='schedule'>
-                  <MuiThemeProvider theme={theme}>
-                    <Paper>
-                      <Scheduler data={data}>
-                        <ViewState currentDate='2018-07-28' />
-                        <WeekView
-                          data={data}
-                          excludedDays={[ 0, 6 ]}
-                          cellDuration={60}
-                          startDayHour={8}
-                          endDayHour={24}
-                        />
-                        <Appointments />
-                      </Scheduler>
-                    </Paper>
-                  </MuiThemeProvider>
-                </div>
+                
+                <Col xs={3}>
+                <ChildBox titleClass={this.state.class} subject={this.state.subject}
+                    lecture={this.state.lecture} 
+                    tutorial={this.state.tutorial}
+                />
+                <br/>
+                <ChildBox titleClass={this.state.class} subject={this.state.subject}
+                    lecture={this.state.lecture} 
+                    tutorial={this.state.tutorial}
+                />
+                <br/>
+                <ChildBox titleClass={this.state.class} subject={this.state.subject}
+                    lecture={this.state.lecture} tutorial={this.state.tutorial}
+                />
+                <br/>
+                <ChildBox titleClass={this.state.class} subject={this.state.subject}
+                    lecture={this.state.lecture} tutorial={this.state.tutorial}
+                />
+                <br/>
+                <ChildBox titleClass={this.state.class} subject={this.state.subject}
+                    lecture={this.state.lecture} tutorial={this.state.tutorial}
+                />
+                </Col>
+                <Col xs={9}> 
+                  <div className='schedule'>
+                    <MuiThemeProvider theme={theme}>
+                      <Paper>
+                        <Scheduler data={data}>
+                          <ViewState currentDate='2018-07-28' />
+                          <WeekView
+                            data={data}
+                            excludedDays={[ 0, 6 ]}
+                            cellDuration={60}
+                            startDayHour={8}
+                            endDayHour={24}
+                          />
+                          <Appointments />
+                        </Scheduler>
+                      </Paper>
+                    </MuiThemeProvider>
+                  </div>
+                </Col>
+                
               </ExpansionPanelDetails>
             </ExpansionPanel>
             <ExpansionPanel>
@@ -232,7 +271,7 @@ class Plan extends Component {
               </ExpansionPanelDetails>
             </ExpansionPanel>
           </Col>
-          <Col xs={2} />
+          <Col xs={1} />
         </Row>
 
       </div>


### PR DESCRIPTION
Added detailed boxes on the left side of the agenda view. (Static for fall 2019 for now). 